### PR TITLE
Updated DotNetZip library

### DIFF
--- a/UploaderAgentConsole/App.config
+++ b/UploaderAgentConsole/App.config
@@ -1,13 +1,21 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
   <appSettings>
-    <add key="singleSeries" value="true"/>
+    <add key="singleSeries" value="true" />
   </appSettings>
   <connectionStrings>
     <!--<add name="cn1" connectionString="Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\Database.mdf;Integrated Security=True"/>-->
-    <add name="cn1" connectionString="Server=CAPITZZRADPAE\SQLEXPRESS;Database=Radiopaedia;Trusted_Connection=False;User Id=appuser1;Password=Password123;Connection Timeout=120"/>    
+    <add name="cn1" connectionString="Server=CAPITZZRADPAE\SQLEXPRESS;Database=Radiopaedia;Trusted_Connection=False;User Id=appuser1;Password=Password123;Connection Timeout=120" />    
   </connectionStrings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/UploaderAgentConsole/UploaderAgentConsole.csproj
+++ b/UploaderAgentConsole/UploaderAgentConsole.csproj
@@ -35,15 +35,15 @@
   <ItemGroup>
     <Reference Include="ClearCanvas.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\CC DLLS\ClearCanvas.Common.dll</HintPath>
+      <HintPath>..\lib\ClearCanvas.Common.dll</HintPath>
     </Reference>
     <Reference Include="ClearCanvas.Desktop, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Work\ClearCanvas DLLs\Built20131203\ClearCanvas.Desktop.dll</HintPath>
+      <HintPath>..\lib\ClearCanvas.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="ClearCanvas.Dicom, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\CC DLLS\ClearCanvas.Dicom.dll</HintPath>
+      <HintPath>..\lib\ClearCanvas.Dicom.dll</HintPath>
     </Reference>
     <Reference Include="ClearCanvas.Dicom.Codec.Jpeg">
       <HintPath>..\..\..\Work\ClearCanvas DLLs\Built20131203\ClearCanvas.Dicom.Codec.Jpeg.dll</HintPath>
@@ -52,31 +52,32 @@
       <HintPath>..\..\..\Work\ClearCanvas DLLs\Built20131203\ClearCanvas.Dicom.Codec.Rle.dll</HintPath>
     </Reference>
     <Reference Include="ClearCanvas.ImageViewer">
-      <HintPath>..\..\..\Work\ClearCanvas DLLs\Built20131203\ClearCanvas.ImageViewer.dll</HintPath>
+      <HintPath>..\lib\ClearCanvas.ImageViewer.dll</HintPath>
     </Reference>
     <Reference Include="ClearCanvas.ImageViewer.Common">
-      <HintPath>..\..\..\Work\ClearCanvas DLLs\Built20131203\ClearCanvas.ImageViewer.Common.dll</HintPath>
+      <HintPath>..\lib\ClearCanvas.ImageViewer.Common.dll</HintPath>
     </Reference>
     <Reference Include="ClearCanvas.ImageViewer.Configuration">
-      <HintPath>..\..\..\Work\ClearCanvas DLLs\Built20131203\ClearCanvas.ImageViewer.Configuration.dll</HintPath>
+      <HintPath>..\lib\ClearCanvas.ImageViewer.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="ClearCanvas.ImageViewer.Core.Functions">
       <HintPath>..\..\..\Work\ClearCanvas DLLs\Built20131203\ClearCanvas.ImageViewer.Core.Functions.dll</HintPath>
     </Reference>
     <Reference Include="ClearCanvas.ImageViewer.Tools.Standard">
-      <HintPath>..\..\..\Work\ClearCanvas DLLs\Built20131203\ClearCanvas.ImageViewer.Tools.Standard.dll</HintPath>
+      <HintPath>..\lib\ClearCanvas.ImageViewer.Tools.Standard.dll</HintPath>
+    </Reference>
+    <Reference Include="ClearCanvas.Utilities.Manifest">
+      <HintPath>..\lib\ClearCanvas.Utilities.Manifest.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetZip, Version=1.13.6.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.13.6\lib\net40\DotNetZip.dll</HintPath>
     </Reference>
     <Reference Include="Grapevine, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Grapevine.3.1.0\lib\net40\Grapevine.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Ionic.Zip, Version=1.9.8.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.9.8\lib\net20\Ionic.Zip.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\CC DLLS\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/UploaderAgentConsole/packages.config
+++ b/UploaderAgentConsole/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.9.8" targetFramework="net452" />
+  <package id="DotNetZip" version="1.13.6" targetFramework="net452" />
   <package id="Grapevine" version="3.1.0" targetFramework="net452" />
+  <package id="log4net" version="2.0.8" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
   <package id="PetaPoco" version="5.1.179" targetFramework="net452" />
   <package id="Topshelf" version="4.0.1" targetFramework="net452" />


### PR DESCRIPTION
Updated reference to DotNetZip library version because of a security vuln (CVE-2018-1002205).
Also added a nuget reference to log4net to save on having to manually add the dll from ClearCanvas. 

I don't think there should be any breaking changes but I don't have an environment to test on so I thought I'd run it past a review for sanity-check.

ClearCanvas DLLs used for testing are here and can be dropped in ./lib if you want to compile:
https://github.com/plwp/ClearCanvas/releases/tag/radiopaedia-uploader-1.0